### PR TITLE
added library variable to keep HDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can find instructions on how to get your Plex library IDs
 | enable_control_flow      | true        | All                            | `{{{args.userVariables.library.enable_control_flow}}}`      | Prevents returning to the controller                   |
 | quality_level            | 21          | Video Transcoding              | `{{{args.userVariables.library.quality_level}}}`            | 18 to 25 recommended. lower = higher quality           |
 | use_nvenc                | false       | Video Transcoding              | `{{{args.userVariables.library.use_nvenc}}}`                | lowercase, true/false                                  |
-| kee_HDR                  | true        | Video Transcoding              | `{{{args.userVariables.library.keep_HDR}}}`                 | lowercase, true/false                                  |
+| keep_HDR                 | true        | Video Transcoding              | `{{{args.userVariables.library.keep_HDR}}}`                 | lowercase, true/false                                  |
 | ffmpeg_preset            | slower      | Video Transcoding              | `{{{args.userVariables.library.ffmpeg_preset}}}`            | lowercase. Options: slower, slow, medium, fast, faster |
 | use_foreign              | false       | Subtitle                       | `{{{args.userVariables.library.use_foreign}}}`              | Optional                                               |
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can find instructions on how to get your Plex library IDs
 | enable_control_flow      | true        | All                            | `{{{args.userVariables.library.enable_control_flow}}}`      | Prevents returning to the controller                   |
 | quality_level            | 21          | Video Transcoding              | `{{{args.userVariables.library.quality_level}}}`            | 18 to 25 recommended. lower = higher quality           |
 | use_nvenc                | false       | Video Transcoding              | `{{{args.userVariables.library.use_nvenc}}}`                | lowercase, true/false                                  |
+| kee_HDR                  | true        | Video Transcoding              | `{{{args.userVariables.library.keep_HDR}}}`                 | lowercase, true/false                                  |
 | ffmpeg_preset            | slower      | Video Transcoding              | `{{{args.userVariables.library.ffmpeg_preset}}}`            | lowercase. Options: slower, slow, medium, fast, faster |
 | use_foreign              | false       | Subtitle                       | `{{{args.userVariables.library.use_foreign}}}`              | Optional                                               |
 

--- a/TDARR_4_videoTranscodingFlow.json
+++ b/TDARR_4_videoTranscodingFlow.json
@@ -109,64 +109,64 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "slower",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "eMjxTGUMF",
       "position": {
         "x": 16.403523848548986,
         "y": 1638.057127675117
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "slower",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "is ffmpeg_preset = slow?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "slow",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "vDbAelujj",
       "position": {
         "x": -107.63363978553936,
         "y": 1559.0693684681858
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "slow",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "is ffmpeg_preset = medium?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "medium",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "ixZp_ki7j",
       "position": {
         "x": -175.7981834907999,
         "y": 1474.4196813253852
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "medium",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "is ffmpeg_preset = fast?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "fast",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "BvmWcuRmu",
       "position": {
         "x": -313.5848202033776,
         "y": 1400.6908638600603
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "fast",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set Video Encoder to HEVC (gpu FASTER)",
@@ -204,95 +204,95 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "faster",
+        "variable": "{{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "UIrqIm9JW",
       "position": {
         "x": -439.85832779556506,
         "y": 1326.8979027559355
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "faster",
-        "variable": "{{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Is it Animated?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "true",
+        "variable": "{{{args.userVariables.library.is_animated}}}"
+      },
       "id": "dXWjz82SS",
       "position": {
         "x": 403.73720348808524,
         "y": 1896.9357799380941
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "true",
-        "variable": "{{{args.userVariables.library.is_animated}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Apply standard tuning",
       "sourceRepo": "Community",
       "pluginName": "ffmpegCommandCustomArguments",
       "version": "1.0.0",
+      "inputsDB": {
+        "outputArguments": "-x265-params \"deblock=-1:-1:psy-rd=1.1:psy-rdoq=1:aq-mode=1:aq-strength=0.80:ipratio=1.4:pbratio=1.3:qpmax=69:qpmin=10:no-cu-lossless=1:no-amp=1:no-rect=1:rskip=1:ctu-info=0:limit-refs=1:no-aq-motion=1:no-dynamic-refine=1:scenecut=40:scenecut-bias=0.1\""
+      },
       "id": "ssm3z_AhC",
       "position": {
         "x": 428.6988166950706,
         "y": 1967.2862857613075
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "outputArguments": "-x265-params \"deblock=-1:-1:psy-rd=1.1:psy-rdoq=1:aq-mode=1:aq-strength=0.80:ipratio=1.4:pbratio=1.3:qpmax=69:qpmin=10:no-cu-lossless=1:no-amp=1:no-rect=1:rskip=1:ctu-info=0:limit-refs=1:no-aq-motion=1:no-dynamic-refine=1:scenecut=40:scenecut-bias=0.1\""
-      }
+      "fpEnabled": true
     },
     {
       "name": "Is it Anime?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "ANIME",
+        "variable": "{{{args.userVariables.library.name}}}"
+      },
       "id": "_1iEFECiV",
       "position": {
         "x": 269.4702754762581,
         "y": 1826.3027198505674
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "ANIME",
-        "variable": "{{{args.userVariables.library.name}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "tune for animation",
       "sourceRepo": "Community",
       "pluginName": "ffmpegCommandCustomArguments",
       "version": "1.0.0",
+      "inputsDB": {
+        "outputArguments": "-tune animation -bf 3 -maxrate 2000k -bufsize 4400k -x265-params \"frame-threads=6:deblock=-2:-2:psy-rd=1:psy-rdoq=0.5:aq-mode=1:aq-strength=0.80:ipratio=1.4:pbratio=1.3:qpmax=69:qpmin=10:no-cu-lossless=1:no-amp=1:no-rect=1:rskip=1:ctu-info=0:limit-refs=1:no-aq-motion=1:scenecut=40:scenecut-bias=0.1:no-sao=1:strong-intra-smoothing=0:no-sao=1\""
+      },
       "id": "RVX-hRdj2",
       "position": {
         "x": 245.59497084626838,
         "y": 1967.8423468040037
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "outputArguments": "-tune animation -bf 3 -maxrate 2000k -bufsize 4400k -x265-params \"frame-threads=6:deblock=-2:-2:psy-rd=1:psy-rdoq=0.5:aq-mode=1:aq-strength=0.80:ipratio=1.4:pbratio=1.3:qpmax=69:qpmin=10:no-cu-lossless=1:no-amp=1:no-rect=1:rskip=1:ctu-info=0:limit-refs=1:no-aq-motion=1:scenecut=40:scenecut-bias=0.1:no-sao=1:strong-intra-smoothing=0:no-sao=1\""
-      }
+      "fpEnabled": true
     },
     {
       "name": "Video File Size Check",
       "sourceRepo": "Community",
       "pluginName": "runClassicTranscodePlugin",
       "version": "2.0.0",
+      "inputsDB": {
+        "pluginSourceId": "Community:Tdarr_Plugin_a9he_New_file_size_check",
+        "lowerBound": "10",
+        "upperBound": "350"
+      },
       "id": "__aruWpNb",
       "position": {
         "x": 155.7054523535007,
         "y": 2282.540028674606
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "pluginSourceId": "Community:Tdarr_Plugin_a9he_New_file_size_check",
-        "lowerBound": "10",
-        "upperBound": "350"
-      }
+      "fpEnabled": true
     },
     {
       "name": "‼️‼️‼️ FAILED VIDEO TRANSCODING DURATION CHECK‼️‼️‼️",
@@ -311,48 +311,48 @@
       "sourceRepo": "Community",
       "pluginName": "goToFlow",
       "version": "2.0.0",
+      "inputsDB": {
+        "flowId": "F4KO4luxb",
+        "pluginId": "L6p4K-XA_"
+      },
       "id": "nQt_qdr3T",
       "position": {
         "x": -255.77601657320974,
         "y": 2622.5062485889657
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "flowId": "F4KO4luxb",
-        "pluginId": "L6p4K-XA_"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set video_has_been_transcoded = false",
       "sourceRepo": "Community",
       "pluginName": "setFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "video_has_been_transcoded",
+        "value": "false"
+      },
       "id": "3gO0_tlfh",
       "position": {
         "x": -230.6352956927634,
         "y": 2441.0121864819776
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "video_has_been_transcoded",
-        "value": "false"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Did we come here from somewhere else?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
+        "value": "true"
+      },
       "id": "2ZBz_8xH-",
       "position": {
         "x": -231.01282252665044,
         "y": 2539.1918865525618
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Replace Original File",
@@ -371,16 +371,16 @@
       "sourceRepo": "Community",
       "pluginName": "goToFlow",
       "version": "2.0.0",
+      "inputsDB": {
+        "flowId": "F4KO4luxb",
+        "pluginId": "L6p4K-XA_"
+      },
       "id": "yXgH5tH67",
       "position": {
         "x": 46.83928184537706,
         "y": 2700.8021321177043
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "flowId": "F4KO4luxb",
-        "pluginId": "L6p4K-XA_"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Decide which quality level to use based off library variable 'quality_level'",
@@ -417,16 +417,16 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "faster",
+        "variable": "{{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "9JFl9MsWX",
       "position": {
         "x": 575.8646071465568,
         "y": 1317.2430045498272
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "faster",
-        "variable": "{{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set Video Encoder to HEVC (cpu SLOWER)",
@@ -451,32 +451,32 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "slower",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "WacgxDBP_",
       "position": {
         "x": 973.1978161505841,
         "y": 1647.6408675777566
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "slower",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "is ffmpeg_preset = slow?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "slow",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "hxCvrSFf5",
       "position": {
         "x": 891.992560788338,
         "y": 1563.1983755194472
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "slow",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set Video Encoder to HEVC (cpu FAST)",
@@ -537,16 +537,16 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "medium",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "UIzkZmDI_",
       "position": {
         "x": 782.1098045920866,
         "y": 1477.4017807620694
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "medium",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Reorder Streams",
@@ -580,46 +580,46 @@
       "sourceRepo": "Community",
       "pluginName": "tagsWorkerType",
       "version": "1.0.0",
+      "inputsDB": {
+        "requiredWorkerType": "GPU:nvenc",
+        "requiredNodeTags": "pc-only"
+      },
       "id": "leytkdC_H",
       "position": {
         "x": 14.21502527193394,
         "y": 1273.865712767936
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "requiredWorkerType": "GPU:nvenc",
-        "requiredNodeTags": "pc-only"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set 720p Resolution",
       "sourceRepo": "Community",
       "pluginName": "ffmpegCommandSetVdeoResolution",
       "version": "1.0.0",
+      "inputsDB": {
+        "targetResolution": "720p"
+      },
       "id": "OArL7awv1",
       "position": {
         "x": -82.02263172746916,
         "y": 873.5479436825725
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "targetResolution": "720p"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set 1080p Resolution",
       "sourceRepo": "Community",
       "pluginName": "ffmpegCommandSetVdeoResolution",
       "version": "1.0.0",
+      "inputsDB": {
+        "targetResolution": "1080p"
+      },
       "id": "65npF4ts2",
       "position": {
         "x": 135.29966060817176,
         "y": 884.1011439839613
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "targetResolution": "1080p"
-      }
+      "fpEnabled": true
     },
     {
       "name": "HEVC file size is gucci.",
@@ -1053,15 +1053,15 @@
       "sourceRepo": "Community",
       "pluginName": "ffmpegCommandSetVdeoResolution",
       "version": "1.0.0",
+      "inputsDB": {
+        "targetResolution": "4KUHD"
+      },
       "id": "vCkfUVzog",
       "position": {
         "x": 406.2511837778445,
         "y": 815.9225424836691
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "targetResolution": "4KUHD"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Check HDR Video",
@@ -1082,8 +1082,8 @@
       "version": "1.0.0",
       "id": "QEY-1emKy",
       "position": {
-        "x": -2.5159569472119756,
-        "y": 1116.7473515732504
+        "x": -63.17239399844564,
+        "y": 1149.6566950797708
       },
       "fpEnabled": true
     },
@@ -1116,63 +1116,63 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "{{{args.userVariables.library.use_nvenc}}}",
+        "value": "true"
+      },
       "id": "yMmOfVyTU",
       "position": {
         "x": 128.0845076332256,
         "y": 1199.987661556221
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "{{{args.userVariables.library.use_nvenc}}}",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Tags: Worker Type CPU",
       "sourceRepo": "Community",
       "pluginName": "tagsWorkerType",
       "version": "1.0.0",
+      "inputsDB": {
+        "requiredWorkerType": "CPU",
+        "requiredNodeTags": "pc-only"
+      },
       "id": "cYIbqVNto",
       "position": {
         "x": 190.64806674376752,
         "y": 1272.615848167122
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "requiredWorkerType": "CPU",
-        "requiredNodeTags": "pc-only"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Tags: Worker Type ANY",
       "sourceRepo": "Community",
       "pluginName": "tagsWorkerType",
       "version": "1.0.0",
+      "inputsDB": {
+        "requiredWorkerType": "CPUorGPU"
+      },
       "id": "4ICjqTwRl",
       "position": {
         "x": 352.09892386100984,
         "y": 2134.624717794056
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "requiredWorkerType": "CPUorGPU"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Set video_has_been_transcoded = 1",
       "sourceRepo": "Community",
       "pluginName": "setFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "video_has_been_transcoded",
+        "value": "true"
+      },
       "id": "Ro8TnPxFO",
       "position": {
         "x": 154.32920772299892,
         "y": 2364.291114543303
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "video_has_been_transcoded",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Run MKVPropEdit",
@@ -1191,31 +1191,31 @@
       "sourceRepo": "Community",
       "pluginName": "runClassicTranscodePlugin",
       "version": "2.0.0",
+      "inputsDB": {
+        "pluginSourceId": "Community:Tdarr_Plugin_z80t_keep_original_date"
+      },
       "id": "9XAIaK9xJ",
       "position": {
         "x": 155.05665814541825,
         "y": 2461.8027795179883
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "pluginSourceId": "Community:Tdarr_Plugin_z80t_keep_original_date"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Is it Anime?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "ANIME",
+        "variable": "{{{args.userVariables.library.name}}}"
+      },
       "id": "zEUftmE3V",
       "position": {
         "x": 184.4953960091438,
         "y": 444.8798336448268
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "ANIME",
-        "variable": "{{{args.userVariables.library.name}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Fail Flow",
@@ -1234,47 +1234,47 @@
       "sourceRepo": "Community",
       "pluginName": "setFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "video_has_been_transcoded",
+        "value": "true"
+      },
       "id": "M8_tUEor7",
       "position": {
         "x": -384.71028209493034,
         "y": 361.43645276731075
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "video_has_been_transcoded",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Video Duration Check",
       "sourceRepo": "Community",
       "pluginName": "runClassicTranscodePlugin",
       "version": "2.0.0",
+      "inputsDB": {
+        "pluginSourceId": "Community:Tdarr_Plugin_a9hf_New_file_duration_check"
+      },
       "id": "eib7fKpbW",
       "position": {
         "x": 352.66508875683235,
         "y": 2209.204603014502
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "pluginSourceId": "Community:Tdarr_Plugin_a9hf_New_file_duration_check"
-      }
+      "fpEnabled": true
     },
     {
       "name": "is ffmpeg_preset = fast?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "value": "fast",
+        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
+      },
       "id": "LVyI_ZqR9",
       "position": {
         "x": 690.5670240088915,
         "y": 1393.3265636333194
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "value": "fast",
-        "variable": "{{{args.userVariables.library.ffmpeg_preset}}}"
-      }
+      "fpEnabled": true
     },
     {
       "name": "All 1080p and 4K videos should be 10-bit color",
@@ -1329,48 +1329,48 @@
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
+        "value": "true"
+      },
       "id": "UqBE23FMd",
       "position": {
         "x": -384.4605098061112,
         "y": 460.6045801153496
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Go To Flow",
       "sourceRepo": "Community",
       "pluginName": "goToFlow",
       "version": "2.0.0",
+      "inputsDB": {
+        "flowId": "F4KO4luxb",
+        "pluginId": "L6p4K-XA_"
+      },
       "id": "iIpAC5gW1",
       "position": {
         "x": -486.74001044857835,
         "y": 545.3850843215666
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "flowId": "F4KO4luxb",
-        "pluginId": "L6p4K-XA_"
-      }
+      "fpEnabled": true
     },
     {
       "name": "Did we come here from somewhere else?",
       "sourceRepo": "Community",
       "pluginName": "checkFlowVariable",
       "version": "1.0.0",
+      "inputsDB": {
+        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
+        "value": "true"
+      },
       "id": "2Y5WnsoKa",
       "position": {
         "x": 153.61130082411742,
         "y": 2614.5188016786997
       },
-      "fpEnabled": true,
-      "inputsDB": {
-        "variable": "{{{args.userVariables.library.enable_control_flow}}}",
-        "value": "true"
-      }
+      "fpEnabled": true
     },
     {
       "name": "On Flow Error",
@@ -1383,6 +1383,22 @@
         "y": 2371.850993746197
       },
       "fpEnabled": true
+    },
+    {
+      "name": "Keep HDR?",
+      "sourceRepo": "Community",
+      "pluginName": "checkFlowVariable",
+      "version": "1.0.0",
+      "id": "RQNtS2WXR",
+      "position": {
+        "x": -85.60012310279154,
+        "y": 1042.2668956555049
+      },
+      "fpEnabled": true,
+      "inputsDB": {
+        "value": "true",
+        "variable": "{{{args.userVariables.library.keep_HDR}}}"
+      }
     }
   ],
   "flowEdges": [
@@ -1686,13 +1702,6 @@
       "target": "OArL7awv1",
       "targetHandle": null,
       "id": "TSdVSu9mz"
-    },
-    {
-      "source": "zHZ9MxuuF",
-      "sourceHandle": "1",
-      "target": "QEY-1emKy",
-      "targetHandle": null,
-      "id": "7V7IfspmI"
     },
     {
       "source": "65npF4ts2",
@@ -2379,6 +2388,27 @@
       "target": "uY7ElPQva",
       "targetHandle": null,
       "id": "abwO63SuY"
+    },
+    {
+      "source": "zHZ9MxuuF",
+      "sourceHandle": "1",
+      "target": "RQNtS2WXR",
+      "targetHandle": null,
+      "id": "0P6PJ5Ozi"
+    },
+    {
+      "source": "RQNtS2WXR",
+      "sourceHandle": "1",
+      "target": "yMmOfVyTU",
+      "targetHandle": null,
+      "id": "EDXXpzxa2"
+    },
+    {
+      "source": "RQNtS2WXR",
+      "sourceHandle": "2",
+      "target": "QEY-1emKy",
+      "targetHandle": null,
+      "id": "WYhut0Uar"
     }
   ]
 }


### PR DESCRIPTION
Added a check flow variable before the ffmpeg command to see if library has a keep_HDR variable. If true, then skip HDR to SDR conversion. 

![image](https://github.com/user-attachments/assets/c04fa51b-1a5d-481b-8351-3faaecfce600)


This can probably be re ordered to put the variable first before the HDR check to reduce resource load. Depending on how the check is performed. 

For some reason exporting the flow from tdarr re ordered a bunch of code, thats why it looks like a bunch of stuff is added and deleted. Not sure if this makes a difference.